### PR TITLE
fix: remove tox-battery package requirement

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,8 +5,10 @@
 #    make upgrade
 #
 asgiref==3.7.2
-    # via django
-certifi==2023.7.22
+    # via
+    #   django
+    #   django-cors-headers
+certifi==2023.11.17
     # via
     #   opsgenie-sdk
     #   requests
@@ -24,7 +26,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   pyjwt
     #   social-auth-core
@@ -47,7 +49,7 @@ django==3.2.23
     #   edx-django-utils
     #   edx-drf-extensions
     #   social-auth-app-django
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/base.in
 django-crum==0.7.9
     # via edx-django-utils
@@ -59,7 +61,7 @@ django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
-django-waffle==4.0.0
+django-waffle==4.1.0
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -76,19 +78,21 @@ edx-auth-backends==4.2.0
     # via -r requirements/base.in
 edx-django-release-util==1.3.0
     # via -r requirements/base.in
-edx-django-utils==5.8.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.13.0
+edx-drf-extensions==9.0.1
     # via -r requirements/base.in
 edx-opaque-keys==2.5.1
     # via edx-drf-extensions
 edx-rest-api-client==5.6.1
     # via -r requirements/base.in
-idna==3.4
+idna==3.6
     # via requests
+importlib-resources==5.13.0
+    # via pycountry
 itypes==1.2.0
     # via coreapi
 jinja2==3.1.2
@@ -97,7 +101,7 @@ markupsafe==2.1.3
     # via jinja2
 mysqlclient==2.2.0
     # via -r requirements/base.in
-newrelic==9.1.1
+newrelic==9.3.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via
@@ -107,11 +111,11 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 opsgenie-sdk==2.1.5
     # via -r requirements/base.in
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
 psutil==5.9.6
     # via edx-django-utils
-pycountry==22.3.5
+pycountry==23.12.7
     # via -r requirements/base.in
 pycparser==2.21
     # via cffi
@@ -151,7 +155,7 @@ requests==2.31.0
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
-responses==0.24.0
+responses==0.24.1
     # via -r requirements/base.in
 semantic-version==2.10.0
     # via edx-drf-extensions
@@ -167,7 +171,7 @@ slumber==0.7.1
     # via edx-rest-api-client
 social-auth-app-django==5.4.0
     # via edx-auth-backends
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   edx-auth-backends
     #   social-auth-app-django
@@ -181,17 +185,19 @@ tenacity==8.2.3
     # via opsgenie-sdk
 testfixtures==7.2.2
     # via -r requirements/base.in
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   asgiref
     #   edx-opaque-keys
 uritemplate==4.1.1
     # via coreapi
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   opsgenie-sdk
     #   requests
     #   responses
+zipp==3.17.0
+    # via importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -3,5 +3,4 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes
 coverage

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 coverage==7.3.2
     # via -r requirements/ci.in
 distlib==0.3.7
@@ -16,26 +22,19 @@ packaging==23.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   tox
     #   virtualenv
 pluggy==1.3.0
     # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==3.28.0
-    # via
-    #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.6.2
+tox==4.11.4
     # via -r requirements/ci.in
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,10 +4,15 @@
 #
 #    make upgrade
 #
+annotated-types==0.6.0
+    # via
+    #   -r requirements/validation.txt
+    #   pydantic
 asgiref==3.7.2
     # via
     #   -r requirements/validation.txt
     #   django
+    #   django-cors-headers
 astroid==3.0.1
     # via
     #   -r requirements/validation.txt
@@ -17,7 +22,15 @@ build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2023.7.22
+cachetools==5.3.2
+    # via
+    #   -r requirements/validation.txt
+    #   tox
+cerberus==1.3.5
+    # via
+    #   -r requirements/validation.txt
+    #   plette
+certifi==2023.11.17
     # via
     #   -r requirements/validation.txt
     #   opsgenie-sdk
@@ -28,7 +41,10 @@ cffi==1.16.0
     #   cryptography
     #   pynacl
 chardet==5.2.0
-    # via diff-cover
+    # via
+    #   -r requirements/validation.txt
+    #   diff-cover
+    #   tox
 charset-normalizer==3.3.2
     # via
     #   -r requirements/validation.txt
@@ -50,6 +66,10 @@ code-annotations==1.5.0
     # via
     #   -r requirements/validation.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/validation.txt
+    #   tox
 coreapi==2.3.3
     # via
     #   -r requirements/validation.txt
@@ -64,20 +84,19 @@ coverage[toml]==7.3.2
     #   -r requirements/validation.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/validation.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/validation.txt
 defusedxml==0.8.0rc2
     # via
     #   -r requirements/validation.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==8.0.0
+diff-cover==8.0.1
     # via -r requirements/dev.in
 dill==0.3.7
     # via
@@ -86,6 +105,7 @@ dill==0.3.7
 distlib==0.3.7
     # via
     #   -r requirements/validation.txt
+    #   requirementslib
     #   virtualenv
 django==3.2.23
     # via
@@ -103,7 +123,7 @@ django==3.2.23
     #   edx-drf-extensions
     #   edx-i18n-tools
     #   social-auth-app-django
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/validation.txt
 django-crum==0.7.9
     # via
@@ -119,7 +139,7 @@ django-rest-swagger==2.2.0
     # via -r requirements/validation.txt
 django-simple-history==3.0.0
     # via -r requirements/validation.txt
-django-waffle==4.0.0
+django-waffle==4.1.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -130,6 +150,10 @@ djangorestframework==3.14.0
     #   django-rest-swagger
     #   drf-jwt
     #   edx-drf-extensions
+docopt==0.6.2
+    # via
+    #   -r requirements/validation.txt
+    #   pipreqs
 docutils==0.20.1
     # via
     #   -r requirements/validation.txt
@@ -142,12 +166,12 @@ edx-auth-backends==4.2.0
     # via -r requirements/validation.txt
 edx-django-release-util==1.3.0
     # via -r requirements/validation.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.13.0
+edx-drf-extensions==9.0.1
     # via -r requirements/validation.txt
 edx-i18n-tools==1.3.0
     # via -r requirements/dev.in
@@ -159,13 +183,13 @@ edx-opaque-keys==2.5.1
     #   edx-drf-extensions
 edx-rest-api-client==5.6.1
     # via -r requirements/validation.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/validation.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/validation.txt
-faker==19.13.0
+faker==20.1.0
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -174,26 +198,27 @@ filelock==3.13.1
     #   -r requirements/validation.txt
     #   tox
     #   virtualenv
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/validation.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt
     #   build
     #   keyring
     #   twine
-importlib-resources==6.1.0
+importlib-resources==5.13.0
     # via
     #   -r requirements/validation.txt
     #   keyring
+    #   pycountry
 iniconfig==2.0.0
     # via
     #   -r requirements/validation.txt
     #   pytest
-isort==5.12.0
+isort==5.13.0
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -205,18 +230,13 @@ jaraco-classes==3.3.0
     # via
     #   -r requirements/validation.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/validation.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/validation.txt
     #   code-annotations
     #   coreschema
     #   diff-cover
-keyring==24.2.0
+keyring==24.3.0
     # via
     #   -r requirements/validation.txt
     #   twine
@@ -246,11 +266,11 @@ more-itertools==10.1.0
     #   jaraco-classes
 mysqlclient==2.2.0
     # via -r requirements/validation.txt
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via
     #   -r requirements/validation.txt
     #   readme-renderer
@@ -270,25 +290,45 @@ packaging==23.2
     #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt
     #   build
+    #   pyproject-api
     #   pytest
     #   tox
-path==16.7.1
+path==16.9.0
     # via edx-i18n-tools
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/validation.txt
     #   stevedore
+pep517==0.13.1
+    # via
+    #   -r requirements/validation.txt
+    #   requirementslib
+pip-api==0.0.30
+    # via
+    #   -r requirements/validation.txt
+    #   isort
 pip-tools==7.3.0
     # via -r requirements/pip-tools.txt
+pipreqs==0.4.13
+    # via
+    #   -r requirements/validation.txt
+    #   isort
 pkginfo==1.9.6
     # via
     #   -r requirements/validation.txt
     #   twine
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -r requirements/validation.txt
     #   pylint
+    #   requirementslib
+    #   tox
     #   virtualenv
+plette[validation]==0.4.4
+    # via
+    #   -r requirements/validation.txt
+    #   plette
+    #   requirementslib
 pluggy==1.3.0
     # via
     #   -r requirements/validation.txt
@@ -301,21 +341,25 @@ psutil==5.9.6
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
-py==1.11.0
-    # via
-    #   -r requirements/validation.txt
-    #   tox
 pycodestyle==2.11.1
     # via -r requirements/validation.txt
-pycountry==22.3.5
+pycountry==23.12.7
     # via -r requirements/validation.txt
 pycparser==2.21
     # via
     #   -r requirements/validation.txt
     #   cffi
+pydantic==2.5.2
+    # via
+    #   -r requirements/validation.txt
+    #   requirementslib
+pydantic-core==2.14.5
+    # via
+    #   -r requirements/validation.txt
+    #   pydantic
 pydocstyle==6.3.0
     # via -r requirements/validation.txt
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   -r requirements/validation.txt
     #   diff-cover
@@ -358,6 +402,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/validation.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
@@ -369,7 +417,7 @@ pytest==7.4.3
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/validation.txt
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via -r requirements/validation.txt
 python-dateutil==2.8.2
     # via
@@ -408,10 +456,12 @@ requests==2.31.0
     #   edx-rest-api-client
     #   requests-oauthlib
     #   requests-toolbelt
+    #   requirementslib
     #   responses
     #   slumber
     #   social-auth-core
     #   twine
+    #   yarg
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/validation.txt
@@ -420,20 +470,20 @@ requests-toolbelt==1.0.0
     # via
     #   -r requirements/validation.txt
     #   twine
-responses==0.24.0
+requirementslib==3.0.0
+    # via
+    #   -r requirements/validation.txt
+    #   isort
+responses==0.24.1
     # via -r requirements/validation.txt
 rfc3986==2.0.0
     # via
     #   -r requirements/validation.txt
     #   twine
-rich==13.6.0
+rich==13.7.0
     # via
     #   -r requirements/validation.txt
     #   twine
-secretstorage==3.3.3
-    # via
-    #   -r requirements/validation.txt
-    #   keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/validation.txt
@@ -450,7 +500,6 @@ six==1.16.0
     #   edx-lint
     #   opsgenie-sdk
     #   python-dateutil
-    #   tox
 slumber==0.7.1
     # via
     #   -r requirements/validation.txt
@@ -463,7 +512,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   -r requirements/validation.txt
     #   edx-auth-backends
@@ -495,47 +544,58 @@ tomli==2.0.1
     #   -r requirements/validation.txt
     #   build
     #   coverage
+    #   pep517
     #   pip-tools
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via
     #   -r requirements/validation.txt
+    #   plette
     #   pylint
-tox==3.28.0
+    #   requirementslib
+tox==4.11.4
     # via -r requirements/validation.txt
 twine==4.0.2
     # via -r requirements/validation.txt
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/validation.txt
+    #   annotated-types
     #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   faker
+    #   pydantic
+    #   pydantic-core
     #   pylint
     #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/validation.txt
     #   coreapi
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -r requirements/validation.txt
     #   opsgenie-sdk
     #   requests
     #   responses
     #   twine
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via
     #   -r requirements/validation.txt
     #   tox
-wheel==0.41.3
+wheel==0.42.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+yarg==0.1.9
+    # via
+    #   -r requirements/validation.txt
+    #   pipreqs
 zipp==3.17.0
     # via
     #   -r requirements/pip-tools.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,10 +8,15 @@ accessible-pygments==0.0.4
     # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
+annotated-types==0.6.0
+    # via
+    #   -r requirements/test.txt
+    #   pydantic
 asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
+    #   django-cors-headers
 astroid==3.0.1
     # via
     #   -r requirements/test.txt
@@ -25,7 +30,15 @@ beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
 build==1.0.3
     # via -r requirements/doc.in
-certifi==2023.7.22
+cachetools==5.3.2
+    # via
+    #   -r requirements/test.txt
+    #   tox
+cerberus==1.3.5
+    # via
+    #   -r requirements/test.txt
+    #   plette
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   opsgenie-sdk
@@ -35,6 +48,10 @@ cffi==1.16.0
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
+chardet==5.2.0
+    # via
+    #   -r requirements/test.txt
+    #   tox
 charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
@@ -54,6 +71,10 @@ code-annotations==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/test.txt
+    #   tox
 coreapi==2.3.3
     # via
     #   -r requirements/test.txt
@@ -68,13 +89,12 @@ coverage[toml]==7.3.2
     #   -r requirements/test.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/test.txt
 defusedxml==0.8.0rc2
     # via
@@ -88,6 +108,7 @@ dill==0.3.7
 distlib==0.3.7
     # via
     #   -r requirements/test.txt
+    #   requirementslib
     #   virtualenv
 django==3.2.23
     # via
@@ -104,7 +125,7 @@ django==3.2.23
     #   edx-django-utils
     #   edx-drf-extensions
     #   social-auth-app-django
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -120,7 +141,7 @@ django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
-django-waffle==4.0.0
+django-waffle==4.1.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -133,6 +154,10 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 doc8==1.1.1
     # via -r requirements/doc.in
+docopt==0.6.2
+    # via
+    #   -r requirements/test.txt
+    #   pipreqs
 docutils==0.19
     # via
     #   doc8
@@ -148,12 +173,12 @@ edx-auth-backends==4.2.0
     # via -r requirements/test.txt
 edx-django-release-util==1.3.0
     # via -r requirements/test.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.13.0
+edx-drf-extensions==9.0.1
     # via -r requirements/test.txt
 edx-lint==5.3.6
     # via -r requirements/test.txt
@@ -163,13 +188,13 @@ edx-opaque-keys==2.5.1
     #   edx-drf-extensions
 edx-rest-api-client==5.6.1
     # via -r requirements/test.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==19.13.0
+faker==20.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -178,25 +203,28 @@ filelock==3.13.1
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   build
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==6.1.0
-    # via keyring
+importlib-resources==5.13.0
+    # via
+    #   -r requirements/test.txt
+    #   keyring
+    #   pycountry
 iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.12.0
+isort==5.13.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -206,17 +234,13 @@ itypes==1.2.0
     #   coreapi
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
     #   sphinx
-keyring==24.2.0
+keyring==24.3.0
     # via twine
 markdown-it-py==3.0.0
     # via rich
@@ -236,11 +260,11 @@ more-itertools==10.1.0
     # via jaraco-classes
 mysqlclient==2.2.0
     # via -r requirements/test.txt
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
 oauthlib==3.2.2
     # via
@@ -258,20 +282,40 @@ packaging==23.2
     #   -r requirements/test.txt
     #   build
     #   pydata-sphinx-theme
+    #   pyproject-api
     #   pytest
     #   sphinx
     #   tox
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
+pep517==0.13.1
+    # via
+    #   -r requirements/test.txt
+    #   requirementslib
+pip-api==0.0.30
+    # via
+    #   -r requirements/test.txt
+    #   isort
+pipreqs==0.4.13
+    # via
+    #   -r requirements/test.txt
+    #   isort
 pkginfo==1.9.6
     # via twine
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -r requirements/test.txt
     #   pylint
+    #   requirementslib
+    #   tox
     #   virtualenv
+plette[validation]==0.4.4
+    # via
+    #   -r requirements/test.txt
+    #   plette
+    #   requirementslib
 pluggy==1.3.0
     # via
     #   -r requirements/test.txt
@@ -281,19 +325,23 @@ psutil==5.9.6
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-py==1.11.0
-    # via
-    #   -r requirements/test.txt
-    #   tox
-pycountry==22.3.5
+pycountry==23.12.7
     # via -r requirements/test.txt
 pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.14.3
+pydantic==2.5.2
+    # via
+    #   -r requirements/test.txt
+    #   requirementslib
+pydantic-core==2.14.5
+    # via
+    #   -r requirements/test.txt
+    #   pydantic
+pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   accessible-pygments
     #   doc8
@@ -338,6 +386,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/test.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via build
 pytest==7.4.3
@@ -347,7 +399,7 @@ pytest==7.4.3
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/test.txt
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via
@@ -384,27 +436,31 @@ requests==2.31.0
     #   edx-rest-api-client
     #   requests-oauthlib
     #   requests-toolbelt
+    #   requirementslib
     #   responses
     #   slumber
     #   social-auth-core
     #   sphinx
     #   twine
+    #   yarg
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via twine
-responses==0.24.0
+requirementslib==3.0.0
+    # via
+    #   -r requirements/test.txt
+    #   isort
+responses==0.24.1
     # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.6.0
+rich==13.7.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
@@ -421,7 +477,6 @@ six==1.16.0
     #   edx-lint
     #   opsgenie-sdk
     #   python-dateutil
-    #   tox
 slumber==0.7.1
     # via
     #   -r requirements/test.txt
@@ -432,7 +487,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -485,27 +540,32 @@ tomli==2.0.1
     #   build
     #   coverage
     #   doc8
+    #   pep517
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via
     #   -r requirements/test.txt
+    #   plette
     #   pylint
-tox==3.28.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/test.txt
+    #   requirementslib
+tox==4.11.4
+    # via -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/doc.in
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/test.txt
+    #   annotated-types
     #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   faker
+    #   pydantic
+    #   pydantic-core
     #   pydata-sphinx-theme
     #   pylint
     #   rich
@@ -513,21 +573,27 @@ uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -r requirements/test.txt
     #   opsgenie-sdk
     #   requests
     #   responses
     #   twine
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via
     #   -r requirements/test.txt
     #   tox
+yarg==0.1.9
+    # via
+    #   -r requirements/test.txt
+    #   pipreqs
 zipp==3.17.0
     # via
+    #   -r requirements/test.txt
     #   importlib-metadata
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via build
 packaging==23.2
     # via build
@@ -21,7 +21,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.41.3
+wheel==0.42.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3.1
     # via -r requirements/pip.in
-setuptools==68.2.2
+setuptools==69.0.2
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,7 +8,8 @@ asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
-certifi==2023.7.22
+    #   django-cors-headers
+certifi==2023.11.17
     # via
     #   -r requirements/base.txt
     #   opsgenie-sdk
@@ -35,7 +36,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -59,7 +60,7 @@ django==3.2.23
     #   edx-django-utils
     #   edx-drf-extensions
     #   social-auth-app-django
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -71,7 +72,7 @@ django-rest-swagger==2.2.0
     # via -r requirements/base.txt
 django-simple-history==3.0.0
     # via -r requirements/base.txt
-django-waffle==4.0.0
+django-waffle==4.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -90,12 +91,12 @@ edx-auth-backends==4.2.0
     # via -r requirements/base.txt
 edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.13.0
+edx-drf-extensions==9.0.1
     # via -r requirements/base.txt
 edx-opaque-keys==2.5.1
     # via
@@ -105,14 +106,18 @@ edx-rest-api-client==5.6.1
     # via -r requirements/base.txt
 gevent==23.9.1
     # via -r requirements/production.in
-greenlet==3.0.1
+greenlet==3.0.2
     # via gevent
 gunicorn==21.2.0
     # via -r requirements/production.in
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests
+importlib-resources==5.13.0
+    # via
+    #   -r requirements/base.txt
+    #   pycountry
 itypes==1.2.0
     # via
     #   -r requirements/base.txt
@@ -129,7 +134,7 @@ mysqlclient==2.2.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -146,7 +151,7 @@ opsgenie-sdk==2.1.5
     # via -r requirements/base.txt
 packaging==23.2
     # via gunicorn
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -154,7 +159,7 @@ psutil==5.9.6
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycountry==22.3.5
+pycountry==23.12.7
     # via -r requirements/base.txt
 pycparser==2.21
     # via
@@ -212,7 +217,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-responses==0.24.0
+responses==0.24.1
     # via -r requirements/base.txt
 semantic-version==2.10.0
     # via
@@ -238,7 +243,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -258,7 +263,7 @@ tenacity==8.2.3
     #   opsgenie-sdk
 testfixtures==7.2.2
     # via -r requirements/base.txt
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/base.txt
     #   asgiref
@@ -267,12 +272,16 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -r requirements/base.txt
     #   opsgenie-sdk
     #   requests
     #   responses
+zipp==3.17.0
+    # via
+    #   -r requirements/base.txt
+    #   importlib-resources
 zope-event==5.0
     # via gevent
 zope-interface==6.1

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,16 +4,29 @@
 #
 #    make upgrade
 #
+annotated-types==0.6.0
+    # via
+    #   -r requirements/test.txt
+    #   pydantic
 asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
+    #   django-cors-headers
 astroid==3.0.1
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-certifi==2023.7.22
+cachetools==5.3.2
+    # via
+    #   -r requirements/test.txt
+    #   tox
+cerberus==1.3.5
+    # via
+    #   -r requirements/test.txt
+    #   plette
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   opsgenie-sdk
@@ -23,6 +36,10 @@ cffi==1.16.0
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
+chardet==5.2.0
+    # via
+    #   -r requirements/test.txt
+    #   tox
 charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
@@ -42,6 +59,10 @@ code-annotations==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/test.txt
+    #   tox
 coreapi==2.3.3
     # via
     #   -r requirements/test.txt
@@ -56,13 +77,12 @@ coverage[toml]==7.3.2
     #   -r requirements/test.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/test.txt
 defusedxml==0.8.0rc2
     # via
@@ -76,6 +96,7 @@ dill==0.3.7
 distlib==0.3.7
     # via
     #   -r requirements/test.txt
+    #   requirementslib
     #   virtualenv
 django==3.2.23
     # via
@@ -92,7 +113,7 @@ django==3.2.23
     #   edx-django-utils
     #   edx-drf-extensions
     #   social-auth-app-django
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -108,7 +129,7 @@ django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
-django-waffle==4.0.0
+django-waffle==4.1.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -119,6 +140,10 @@ djangorestframework==3.14.0
     #   django-rest-swagger
     #   drf-jwt
     #   edx-drf-extensions
+docopt==0.6.2
+    # via
+    #   -r requirements/test.txt
+    #   pipreqs
 docutils==0.20.1
     # via readme-renderer
 drf-jwt==1.19.2
@@ -129,12 +154,12 @@ edx-auth-backends==4.2.0
     # via -r requirements/test.txt
 edx-django-release-util==1.3.0
     # via -r requirements/test.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.13.0
+edx-drf-extensions==9.0.1
     # via -r requirements/test.txt
 edx-lint==5.3.6
     # via
@@ -146,13 +171,13 @@ edx-opaque-keys==2.5.1
     #   edx-drf-extensions
 edx-rest-api-client==5.6.1
     # via -r requirements/test.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==19.13.0
+faker==20.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -161,21 +186,24 @@ filelock==3.13.1
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   keyring
     #   twine
-importlib-resources==6.1.0
-    # via keyring
+importlib-resources==5.13.0
+    # via
+    #   -r requirements/test.txt
+    #   keyring
+    #   pycountry
 iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.12.0
+isort==5.13.0
     # via
     #   -r requirements/quality.in
     #   -r requirements/test.txt
@@ -186,16 +214,12 @@ itypes==1.2.0
     #   coreapi
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
-keyring==24.2.0
+keyring==24.3.0
     # via twine
 markdown-it-py==3.0.0
     # via rich
@@ -215,11 +239,11 @@ more-itertools==10.1.0
     # via jaraco-classes
 mysqlclient==2.2.0
     # via -r requirements/test.txt
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
 oauthlib==3.2.2
     # via
@@ -235,19 +259,39 @@ opsgenie-sdk==2.1.5
 packaging==23.2
     # via
     #   -r requirements/test.txt
+    #   pyproject-api
     #   pytest
     #   tox
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
+pep517==0.13.1
+    # via
+    #   -r requirements/test.txt
+    #   requirementslib
+pip-api==0.0.30
+    # via
+    #   -r requirements/test.txt
+    #   isort
+pipreqs==0.4.13
+    # via
+    #   -r requirements/test.txt
+    #   isort
 pkginfo==1.9.6
     # via twine
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -r requirements/test.txt
     #   pylint
+    #   requirementslib
+    #   tox
     #   virtualenv
+plette[validation]==0.4.4
+    # via
+    #   -r requirements/test.txt
+    #   plette
+    #   requirementslib
 pluggy==1.3.0
     # via
     #   -r requirements/test.txt
@@ -257,21 +301,25 @@ psutil==5.9.6
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-py==1.11.0
-    # via
-    #   -r requirements/test.txt
-    #   tox
 pycodestyle==2.11.1
     # via -r requirements/quality.in
-pycountry==22.3.5
+pycountry==23.12.7
     # via -r requirements/test.txt
 pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
+pydantic==2.5.2
+    # via
+    #   -r requirements/test.txt
+    #   requirementslib
+pydantic-core==2.14.5
+    # via
+    #   -r requirements/test.txt
+    #   pydantic
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   readme-renderer
     #   rich
@@ -312,6 +360,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/test.txt
+    #   tox
 pytest==7.4.3
     # via
     #   -r requirements/test.txt
@@ -319,7 +371,7 @@ pytest==7.4.3
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/test.txt
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via
@@ -355,24 +407,28 @@ requests==2.31.0
     #   edx-rest-api-client
     #   requests-oauthlib
     #   requests-toolbelt
+    #   requirementslib
     #   responses
     #   slumber
     #   social-auth-core
     #   twine
+    #   yarg
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via twine
-responses==0.24.0
+requirementslib==3.0.0
+    # via
+    #   -r requirements/test.txt
+    #   isort
+responses==0.24.1
     # via -r requirements/test.txt
 rfc3986==2.0.0
     # via twine
-rich==13.6.0
+rich==13.7.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
@@ -389,7 +445,6 @@ six==1.16.0
     #   edx-lint
     #   opsgenie-sdk
     #   python-dateutil
-    #   tox
 slumber==0.7.1
     # via
     #   -r requirements/test.txt
@@ -400,7 +455,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -429,47 +484,58 @@ tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
+    #   pep517
     #   pylint
+    #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via
     #   -r requirements/test.txt
+    #   plette
     #   pylint
-tox==3.28.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/test.txt
+    #   requirementslib
+tox==4.11.4
+    # via -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.in
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/test.txt
+    #   annotated-types
     #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   faker
+    #   pydantic
+    #   pydantic-core
     #   pylint
     #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -r requirements/test.txt
     #   opsgenie-sdk
     #   requests
     #   responses
     #   twine
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via
     #   -r requirements/test.txt
     #   tox
+yarg==0.1.9
+    # via
+    #   -r requirements/test.txt
+    #   pipreqs
 zipp==3.17.0
     # via
+    #   -r requirements/test.txt
     #   importlib-metadata
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,15 +4,22 @@
 #
 #    make upgrade
 #
+annotated-types==0.6.0
+    # via pydantic
 asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
+    #   django-cors-headers
 astroid==3.0.1
     # via
     #   pylint
     #   pylint-celery
-certifi==2023.7.22
+cachetools==5.3.2
+    # via tox
+cerberus==1.3.5
+    # via plette
+certifi==2023.11.17
     # via
     #   -r requirements/base.txt
     #   opsgenie-sdk
@@ -22,6 +29,8 @@ cffi==1.16.0
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
+chardet==5.2.0
+    # via tox
 charset-normalizer==3.3.2
     # via
     #   -r requirements/base.txt
@@ -39,6 +48,8 @@ code-annotations==1.5.0
     # via
     #   -r requirements/test.in
     #   edx-lint
+colorama==0.4.6
+    # via tox
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -52,12 +63,12 @@ coverage[toml]==7.3.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/base.txt
     #   pyjwt
     #   social-auth-core
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/test.in
 defusedxml==0.8.0rc2
     # via
@@ -67,7 +78,9 @@ defusedxml==0.8.0rc2
 dill==0.3.7
     # via pylint
 distlib==0.3.7
-    # via virtualenv
+    # via
+    #   requirementslib
+    #   virtualenv
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
@@ -82,7 +95,7 @@ distlib==0.3.7
     #   edx-django-utils
     #   edx-drf-extensions
     #   social-auth-app-django
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -98,7 +111,7 @@ django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
-django-waffle==4.0.0
+django-waffle==4.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -109,6 +122,8 @@ djangorestframework==3.14.0
     #   django-rest-swagger
     #   drf-jwt
     #   edx-drf-extensions
+docopt==0.6.2
+    # via pipreqs
 drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
@@ -117,12 +132,12 @@ edx-auth-backends==4.2.0
     # via -r requirements/base.txt
 edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.13.0
+edx-drf-extensions==9.0.1
     # via -r requirements/base.txt
 edx-lint==5.3.6
     # via -r requirements/test.in
@@ -132,11 +147,11 @@ edx-opaque-keys==2.5.1
     #   edx-drf-extensions
 edx-rest-api-client==5.6.1
     # via -r requirements/base.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==19.13.0
+faker==20.1.0
     # via
     #   -r requirements/test.in
     #   factory-boy
@@ -144,13 +159,17 @@ filelock==3.13.1
     # via
     #   tox
     #   virtualenv
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests
+importlib-resources==5.13.0
+    # via
+    #   -r requirements/base.txt
+    #   pycountry
 iniconfig==2.0.0
     # via pytest
-isort==5.12.0
+isort==5.13.0
     # via pylint
 itypes==1.2.0
     # via
@@ -171,7 +190,7 @@ mock==5.1.0
     # via -r requirements/test.in
 mysqlclient==2.2.0
     # via -r requirements/base.txt
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -188,16 +207,27 @@ opsgenie-sdk==2.1.5
     # via -r requirements/base.txt
 packaging==23.2
     # via
+    #   pyproject-api
     #   pytest
     #   tox
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==3.11.0
+pep517==0.13.1
+    # via requirementslib
+pip-api==0.0.30
+    # via isort
+pipreqs==0.4.13
+    # via isort
+platformdirs==4.1.0
     # via
     #   pylint
+    #   requirementslib
+    #   tox
     #   virtualenv
+plette[validation]==0.4.4
+    # via requirementslib
 pluggy==1.3.0
     # via
     #   pytest
@@ -206,14 +236,16 @@ psutil==5.9.6
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-py==1.11.0
-    # via tox
-pycountry==22.3.5
+pycountry==23.12.7
     # via -r requirements/base.txt
 pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
+pydantic==2.5.2
+    # via requirementslib
+pydantic-core==2.14.5
+    # via pydantic
 pyjwt[crypto]==2.8.0
     # via
     #   -r requirements/base.txt
@@ -245,13 +277,15 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+pyproject-api==1.6.1
+    # via tox
 pytest==7.4.3
     # via
     #   pytest-cov
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/test.in
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via
@@ -282,14 +316,18 @@ requests==2.31.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
+    #   requirementslib
     #   responses
     #   slumber
     #   social-auth-core
+    #   yarg
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-responses==0.24.0
+requirementslib==3.0.0
+    # via isort
+responses==0.24.1
     # via -r requirements/base.txt
 semantic-version==2.10.0
     # via
@@ -307,7 +345,6 @@ six==1.16.0
     #   edx-lint
     #   opsgenie-sdk
     #   python-dateutil
-    #   tox
 slumber==0.7.1
     # via
     #   -r requirements/base.txt
@@ -316,7 +353,7 @@ social-auth-app-django==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -342,35 +379,48 @@ text-unidecode==1.3
 tomli==2.0.1
     # via
     #   coverage
+    #   pep517
     #   pylint
+    #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.2
-    # via pylint
-tox==3.28.0
+tomlkit==0.12.3
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/test.in
-typing-extensions==4.8.0
+    #   plette
+    #   pylint
+    #   requirementslib
+tox==4.11.4
+    # via -r requirements/test.in
+typing-extensions==4.9.0
     # via
     #   -r requirements/base.txt
+    #   annotated-types
     #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   faker
+    #   pydantic
+    #   pydantic-core
     #   pylint
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -r requirements/base.txt
     #   opsgenie-sdk
     #   requests
     #   responses
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via tox
+yarg==0.1.9
+    # via pipreqs
+zipp==3.17.0
+    # via
+    #   -r requirements/base.txt
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -4,18 +4,34 @@
 #
 #    make upgrade
 #
+annotated-types==0.6.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pydantic
 asgiref==3.7.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
+    #   django-cors-headers
 astroid==3.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-certifi==2023.7.22
+cachetools==5.3.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   tox
+cerberus==1.3.5
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   plette
+certifi==2023.11.17
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -27,6 +43,11 @@ cffi==1.16.0
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
+chardet==5.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   tox
 charset-normalizer==3.3.2
     # via
     #   -r requirements/quality.txt
@@ -50,6 +71,11 @@ code-annotations==1.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   tox
 coreapi==2.3.3
     # via
     #   -r requirements/quality.txt
@@ -67,14 +93,13 @@ coverage[toml]==7.3.2
     #   -r requirements/test.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
-ddt==1.6.0
+ddt==1.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -93,6 +118,7 @@ distlib==0.3.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   requirementslib
     #   virtualenv
 django==3.2.23
     # via
@@ -109,7 +135,7 @@ django==3.2.23
     #   edx-django-utils
     #   edx-drf-extensions
     #   social-auth-app-django
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -134,7 +160,7 @@ django-simple-history==3.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-waffle==4.0.0
+django-waffle==4.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -147,6 +173,11 @@ djangorestframework==3.14.0
     #   django-rest-swagger
     #   drf-jwt
     #   edx-drf-extensions
+docopt==0.6.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pipreqs
 docutils==0.20.1
     # via
     #   -r requirements/quality.txt
@@ -164,13 +195,13 @@ edx-django-release-util==1.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==5.8.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.13.0
+edx-drf-extensions==9.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -187,7 +218,7 @@ edx-rest-api-client==5.6.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -196,7 +227,7 @@ factory-boy==3.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==19.13.0
+faker==20.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -207,26 +238,28 @@ filelock==3.13.1
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   -r requirements/quality.txt
     #   keyring
     #   twine
-importlib-resources==6.1.0
+importlib-resources==5.13.0
     # via
     #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   keyring
+    #   pycountry
 iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest
-isort==5.12.0
+isort==5.13.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -240,18 +273,13 @@ jaraco-classes==3.3.0
     # via
     #   -r requirements/quality.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
-keyring==24.2.0
+keyring==24.3.0
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -285,12 +313,12 @@ mysqlclient==2.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -313,23 +341,47 @@ packaging==23.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   pyproject-api
     #   pytest
     #   tox
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   stevedore
+pep517==0.13.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   requirementslib
+pip-api==0.0.30
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   isort
+pipreqs==0.4.13
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   isort
 pkginfo==1.9.6
     # via
     #   -r requirements/quality.txt
     #   twine
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
+    #   requirementslib
+    #   tox
     #   virtualenv
+plette[validation]==0.4.4
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   plette
+    #   requirementslib
 pluggy==1.3.0
     # via
     #   -r requirements/quality.txt
@@ -341,14 +393,9 @@ psutil==5.9.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-py==1.11.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   tox
 pycodestyle==2.11.1
     # via -r requirements/quality.txt
-pycountry==22.3.5
+pycountry==23.12.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -357,9 +404,19 @@ pycparser==2.21
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cffi
+pydantic==2.5.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   requirementslib
+pydantic-core==2.14.5
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pydantic
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -408,6 +465,11 @@ pynacl==1.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   tox
 pytest==7.4.3
     # via
     #   -r requirements/quality.txt
@@ -418,7 +480,7 @@ pytest-cov==4.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -464,10 +526,12 @@ requests==2.31.0
     #   edx-rest-api-client
     #   requests-oauthlib
     #   requests-toolbelt
+    #   requirementslib
     #   responses
     #   slumber
     #   social-auth-core
     #   twine
+    #   yarg
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/quality.txt
@@ -477,7 +541,12 @@ requests-toolbelt==1.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-responses==0.24.0
+requirementslib==3.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   isort
+responses==0.24.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -485,14 +554,10 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==13.6.0
+rich==13.7.0
     # via
     #   -r requirements/quality.txt
     #   twine
-secretstorage==3.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/quality.txt
@@ -512,7 +577,6 @@ six==1.16.0
     #   edx-lint
     #   opsgenie-sdk
     #   python-dateutil
-    #   tox
 slumber==0.7.1
     # via
     #   -r requirements/quality.txt
@@ -527,7 +591,7 @@ social-auth-app-django==5.4.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.0
+social-auth-core==4.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -564,28 +628,35 @@ tomli==2.0.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coverage
+    #   pep517
     #   pylint
+    #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   plette
     #   pylint
-tox==3.28.0
+    #   requirementslib
+tox==4.11.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
 twine==4.0.2
     # via -r requirements/quality.txt
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   annotated-types
     #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   faker
+    #   pydantic
+    #   pydantic-core
     #   pylint
     #   rich
 uritemplate==4.1.1
@@ -593,7 +664,7 @@ uritemplate==4.1.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -601,16 +672,23 @@ urllib3==2.0.7
     #   requests
     #   responses
     #   twine
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   tox
+yarg==0.1.9
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   pipreqs
 zipp==3.17.0
     # via
     #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   importlib-metadata
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
## Description
- Remove `tox-battery` from package requirements since it is not needed with `tox v4` now.
- Updated `tox` to `v4` by upgrading all requirements.